### PR TITLE
Travis CI: Explain why we use "cpp" instead of "python"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# This deliverately is not "python" as a work-around to support
+# multi-os builds with custom Python versions in Travis CI.
 language: cpp
 
 os: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# This deliverately is not "python" as a work-around to support
+# This deliberately is not "python" as a work-around to support
 # multi-os builds with custom Python versions in Travis CI.
 language: cpp
 


### PR DESCRIPTION
Because that deserves some explanation.