### PR TITLE
Alternate or later handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,14 +61,14 @@ For example::
 
     >>> from license_expression import Licensing, LicenseSymbol
     >>> licensing = Licensing()
-    >>> expression = ' GPL-2.0 or LGPL 2.1 and mit '
+    >>> expression = ' GPL-2.0 or LGPL-2.1 and mit '
     >>> parsed = licensing.parse(expression)
-    >>> expected = 'GPL-2.0 OR (LGPL 2.1 AND mit)'
+    >>> expected = 'GPL-2.0 OR (LGPL-2.1 AND mit)'
     >>> assert expected == parsed.render('{symbol.key}')
 
     >>> expected = [
     ...   LicenseSymbol('GPL-2.0'),
-    ...   LicenseSymbol('LGPL 2.1'),
+    ...   LicenseSymbol('LGPL-2.1'),
     ...   LicenseSymbol('mit')
     ... ]
     >>> assert expected == licensing.license_symbols(expression)

--- a/README.rst
+++ b/README.rst
@@ -74,15 +74,15 @@ For example::
     >>> assert expected == licensing.license_symbols(expression)
     >>> assert expected == licensing.license_symbols(parsed)
 
-    >>> symbols = ['GPL-2.0+', 'Classpath', 'BSD']
+    >>> symbols = ['GPL-2.0', 'Classpath', 'BSD']
     >>> licensing = Licensing(symbols)
     >>> expression = 'GPL-2.0+ with Classpath or (bsd)'
     >>> parsed = licensing.parse(expression)
     >>> expected = 'GPL-2.0+ WITH Classpath OR BSD'
-    >>> assert expected == parsed.render('{symbol.key}')
+    >>> assert expected == parsed.render('{symbol.key}', '{symbol.key}+')
 
     >>> expected = [
-    ...   LicenseSymbol('GPL-2.0+'),
+    ...   LicenseSymbol('GPL-2.0', or_later=True    ),
     ...   LicenseSymbol('Classpath', is_exception=True),
     ...   LicenseSymbol('BSD')
     ... ]


### PR DESCRIPTION
This implements alternative tokenizers: an automaton based one and a regex-based one. It now deals properly with Licensing created without symbols and the case where keys can contain keywords such as "or" or "and" 