### PR TITLE
Licensing.parse: Raise ExpressionParseError instead of ParseError

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ The following organizations or individuals have contributed to this code:
 - nexB Inc. @nexB
 - Philippe Ombredanne @pombredanne
 - Thomas Druez @tdruez
+- Carmen Bianca Bakker @carmenbianca

--- a/src/license_expression/__init__.py
+++ b/src/license_expression/__init__.py
@@ -103,6 +103,10 @@ class ExpressionError(Exception):
     pass
 
 
+class ExpressionParseError(ParseError, ExpressionError):
+    pass
+
+
 # Used for tokenizing
 Keyword = namedtuple('Keyword', 'value type')
 Keyword.__len__ = lambda self: len(self.value)
@@ -380,7 +384,7 @@ class Licensing(boolean.BooleanAlgebra):
         """
         Return a new license LicenseExpression object by parsing a license
         `expression` string. Check that the expression syntax is valid and raise
-        an Exception, an ExpressionError or a ParseError on errors.
+        an ExpressionError or an ExpressionParseError on errors.
         Return None for empty expressions.
         `expression` is either a string or a LicenseExpression object. If this
         is a LicenseExpression it is returned as-is.
@@ -433,9 +437,11 @@ class Licensing(boolean.BooleanAlgebra):
             # this will raise a ParseError on errors
             tokens = list(self.tokenize(expression, strict=strict, simple=simple))
             expression = super(Licensing, self).parse(tokens)
-        except TypeError as e:
-            msg = 'Invalid expression syntax: ' + repr(e)
-            raise ExpressionError(msg)
+        except ParseError as e:
+            new_error = ExpressionParseError(
+                token_type=e.token_type, token_string=e.token_string,
+                position=e.position, error_code=e.error_code)
+            raise new_error from e
 
         if not isinstance(expression, LicenseExpression):
             raise ExpressionError('expression must be a LicenseExpression once parsed.')

--- a/src/license_expression/__init__.py
+++ b/src/license_expression/__init__.py
@@ -441,7 +441,7 @@ class Licensing(boolean.BooleanAlgebra):
             new_error = ExpressionParseError(
                 token_type=e.token_type, token_string=e.token_string,
                 position=e.position, error_code=e.error_code)
-            raise new_error from e
+            raise new_error
 
         if not isinstance(expression, LicenseExpression):
             raise ExpressionError('expression must be a LicenseExpression once parsed.')


### PR DESCRIPTION
Fixes #35.

I also removed the `except TypeError` statement inside of the method. It didn't appear to do much that I could see. It didn't light up any tests when I removed it, either.

```
ExpressionParseError is a subclass of both ParseError and
ExpressionError. This allows the user to do `except ParseError`
as they had done before, and nothing will break. If the user does
`except ExpressionError`, the ParseErrors will now also be caught.

The advantage of doing this is that `except ExpressionError` now
catches all exceptions coming out of this method.

This is therefore a breaking change.

Signed-off-by: Carmen Bianca Bakker <carmen@carmenbianca.eu>
```