### PR TITLE
Fix anomalous backslashes in strings

### DIFF
--- a/src/license_expression/__init__.py
+++ b/src/license_expression/__init__.py
@@ -128,7 +128,7 @@ KEYWORDS_STRINGS = set(kw.value for kw in KEYWORDS)
 # mapping of lowercase operator strings to an operator object
 OPERATORS = {'and': KW_AND, 'or': KW_OR, 'with': KW_WITH}
 
-_simple_tokenizer = re.compile('''
+_simple_tokenizer = re.compile(r'''
     (?P<symop>[^\s\(\)]+)
      |
     (?P<space>\s+)

--- a/src/license_expression/_pyahocorasick.py
+++ b/src/license_expression/_pyahocorasick.py
@@ -608,7 +608,7 @@ class Token(object):
 
 
 # tokenize to separate text from parens
-_tokenizer = re.compile('''
+_tokenizer = re.compile(r'''
     (?P<text>[^\s\(\)]+)
      |
     (?P<space>\s+)


### PR DESCRIPTION
Python 3.8 emits a SyntaxWarning for a string with an anomalous backslash, e.g.:

  <unknown>:127: SyntaxWarning: invalid escape sequence \s

Fix by adding the missing 'r' prefix.