### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,9 +23,9 @@ SPDX and SBOM in general) as a way to express licensing precisely.
 
 ``license-expression`` is a comprehensive utility library to parse, compare,
 simplify and normalize these license expressions (such as SPDX license expressions)
-using boolean logic like in: `GPL-2.0 or later WITH Classpath Exception AND MIT`.
+using boolean logic like in: `GPL-2.0-or-later WITH Classpath-exception-2.0 AND MIT`.
 
-It includes the license keys from SPDX https://spdx.org/licenses/ (version 3.13)
+It includes the license keys from SPDX https://spdx.org/licenses/ (Update README.rst)
 and ScanCode license DB (version 21.6.7) https://scancode-licensedb.aboutcode.org/
 to get started quickly.
 

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ SPDX and SBOM in general) as a way to express licensing precisely.
 simplify and normalize these license expressions (such as SPDX license expressions)
 using boolean logic like in: `GPL-2.0-or-later WITH Classpath-exception-2.0 AND MIT`.
 
-It includes the license keys from SPDX https://spdx.org/licenses/ (Update README.rst)
+It includes the license keys from SPDX https://spdx.org/licenses/ (version 3.19)
 and ScanCode license DB (version 21.6.7) https://scancode-licensedb.aboutcode.org/
 to get started quickly.
 


### PR DESCRIPTION
Update README.rst:
- SPDX license list 3.19
- correct syntax for "GPL-2.0-or-later WITH Classpath-exception-2.0 AND MIT"

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>
