### PR TITLE
Fix python_requires by changing >=3.6.* to >=3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ zip_safe = false
 
 setup_requires = setuptools_scm[toml] >= 4
 
-python_requires = >=3.6.*
+python_requires = >=3.6
 
 install_requires =
     boolean.py >= 4.0


### PR DESCRIPTION
pdm fails to install this package because of it, but I think it's enough to point to [Requires-python in Core Metadata](https://packaging.python.org/en/latest/specifications/core-metadata/#requires-python) which points to PEP 440 and prefix matching is only supported for `==`.