### PR TITLE
Fix missing release wheels

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -28,15 +28,15 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - name: Install pypa/build and twine
         run: python -m pip install --user --upgrade build twine pkginfo
 
       - name: Build a binary wheel and a source tarball
-        run: python -m build --sdist --outdir dist/
+        run: python -m build --wheel --sdist --outdir dist/
 
-      - name: Validate wheel and sdis for Pypi
+      - name: Validate wheels and sdists for Pypi
         run: python -m twine check dist/*
 
       - name: Upload built archives

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v30.4.3 - 2025-06-25
+--------------------
+
+This is a minor bugfix release:
+
+- Release license-expression wheels properly
+
 v30.4.2 - 2025-06-25
 --------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = license-expression
-version = 30.4.2
+version = 30.4.3
 license = Apache-2.0
 
 # description must be on ONE line https://github.com/pypa/setuptools/issues/1390


### PR DESCRIPTION
[license-expression@30.4.2](https://pypi.org/project/license-expression/30.4.2/) is missing wheels due to a mistake while merging skeleton onto https://github.com/aboutcode-org/license-expression/pull/115