### PR TITLE
Fix 'MPL-2.0-no-copyleft-exception'

### DIFF
--- a/src/license_expression/data/scancode-licensedb-index.json
+++ b/src/license_expression/data/scancode-licensedb-index.json
@@ -17852,7 +17852,7 @@
     "category": "Copyleft Limited",
     "spdx_license_key": "MPL-2.0-no-copyleft-exception",
     "other_spdx_license_keys": [],
-    "is_exception": true,
+    "is_exception": false,
     "is_deprecated": false,
     "json": "mpl-2.0-no-copyleft-exception.json",
     "yaml": "mpl-2.0-no-copyleft-exception.yml",


### PR DESCRIPTION
The license 'MPL-2.0-no-copyleft-exception' is listed at https://github.com/spdx/license-list-data/blob/main/json/licenses.json#L5804. Its 'is_exception' should be 'false'.